### PR TITLE
bump jetty runner version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY prebuilds/ /prebuilds/
 COPY package/ /app/libresonic/
 
 # package version settings
-ARG JETTY_VER="9.3.10.v20160621"
+ARG JETTY_VER="9.3.14.v20161028"
 
 # environment settings
 ARG JETTY_NAME=jetty-runner

--- a/README.md
+++ b/README.md
@@ -89,5 +89,6 @@ Default user/pass is admin/admin
 
 ## Versions
 
++ **04.12.16:** Update jetty runner version.
 + **29.11.16:** Switch to building from release tags following v6.1 stable release.
 + **17.11.16:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ update jetty runner version to 9.3.14.v20161028